### PR TITLE
Add parser for ResetCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ResetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetCommand.java
@@ -13,6 +13,10 @@ public class ResetCommand extends Command {
 
     public static final String COMMAND_WORD = "reset";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Resets the student list to its original state\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Reset student list to original state";
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CodeSphereParser.java
+++ b/src/main/java/seedu/address/logic/parser/CodeSphereParser.java
@@ -140,9 +140,6 @@ public class CodeSphereParser {
         case PendingQuestionCommand.COMMAND_WORD:
             return new PendingQuestionCommandParser().parse(arguments);
 
-        case ResetCommand.COMMAND_WORD:
-            return new ResetCommand();
-
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
@@ -154,6 +151,9 @@ public class CodeSphereParser {
 
         case SortCommand.COMMAND_WORD:
             return new SortCommandParser().parse(arguments);
+
+        case ResetCommand.COMMAND_WORD:
+            return new ResetCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ResetCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ResetCommand object
+ */
+public class ResetCommandParser implements Parser<ResetCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ResetCommand
+     * and returns a ResetCommand object for execution.
+     * @throws ParseException If the user input does not conform to the expected format
+     */
+    public ResetCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        if (argMultimap.getPreamble().isEmpty()) {
+            return new ResetCommand();
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResetCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Previously "reset abc" works, but new parser added ensures that nothing should follow behind the reset keyword.