### PR TITLE
Add find course feature and reset the course list after find

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COURSE_DISPLAYED_INDEX = "The course index provided is invalid";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_COURSES_LISTED_OVERVIEW = "%1$d courses listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/FindCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCourseCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.course.Course;
+
+/**
+ * Finds and lists all courses with name contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindCourseCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all courses with names containing any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " CS";
+
+    private final Predicate<Course> predicate;
+
+    /**
+     * Constructs a FindCourseCommand with the specified predicate for filtering.
+     *
+     * @param predicate A predicate that filters entities based on the course names.
+     */
+    public FindCourseCommand(Predicate <Course> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredCourseList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_COURSES_LISTED_OVERVIEW, model.getFilteredCourseList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindCourseCommand)) {
+            return false;
+        }
+
+        FindCourseCommand otherFindCourseCommand = (FindCourseCommand) other;
+
+        return predicate.equals(otherFindCourseCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ResetCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetCourseCommand.java
@@ -6,7 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COURSES;
 import seedu.address.model.Model;
 
 /**
- * Resets the current listed students to the original state.
+ * Resets the current listed courses to the original state.
  */
 public class ResetCourseCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ResetCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetCourseCommand.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COURSES;
+
+import seedu.address.model.Model;
+
+/**
+ * Resets the current listed students to the original state.
+ */
+public class ResetCourseCommand extends Command {
+
+    public static final String COMMAND_WORD = "reset";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Resets the course list to its original state\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Reset course list to original state";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredCourseList(PREDICATE_SHOW_ALL_COURSES);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CodeSphereParser.java
+++ b/src/main/java/seedu/address/logic/parser/CodeSphereParser.java
@@ -19,12 +19,14 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCourseCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindCourseCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HomeCommand;
 import seedu.address.logic.commands.PendingQuestionCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.ResetCommand;
+import seedu.address.logic.commands.ResetCourseCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -81,26 +83,32 @@ public class CodeSphereParser {
         case AddCourseCommand.COMMAND_WORD:
             return new AddCourseCommandParser().parse(arguments);
 
-        case EditCourseCommand.COMMAND_WORD:
-            return new EditCourseCommandParser().parse(arguments);
+        case ClearCourseCommand.COMMAND_WORD:
+            return new ClearCourseCommand();
 
         case DeleteCourseCommand.COMMAND_WORD:
             return new DeleteCourseCommandParser().parse(arguments);
 
-        case SelectCommand.COMMAND_WORD:
-            return new SelectCommandParser().parse(arguments);
-
-        case ClearCourseCommand.COMMAND_WORD:
-            return new ClearCourseCommand();
+        case EditCourseCommand.COMMAND_WORD:
+            return new EditCourseCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
+        case FindCourseCommand.COMMAND_WORD:
+            return new FindCourseCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
         case HomeCommand.COMMAND_WORD:
             return new HomeCommandParser().parse(arguments);
+
+        case ResetCourseCommand.COMMAND_WORD:
+            return new ResetCourseCommandParser().parse(arguments);
+
+        case SelectCommand.COMMAND_WORD:
+            return new SelectCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
@@ -120,29 +128,20 @@ public class CodeSphereParser {
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
-        case RemarkCommand.COMMAND_WORD:
-            return new RemarkCommandParser().parse(arguments);
-
-        case RemoveCommand.COMMAND_WORD:
-            return new RemoveCommandParser().parse(arguments);
-
-        case PendingQuestionCommand.COMMAND_WORD:
-            return new PendingQuestionCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
+        case FindCommand.COMMAND_WORD:
+            return new FindCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
@@ -150,11 +149,20 @@ public class CodeSphereParser {
         case HomeCommand.COMMAND_WORD:
             return new HomeCommandParser().parse(arguments);
 
-        case SortCommand.COMMAND_WORD:
-            return new SortCommandParser().parse(arguments);
+        case PendingQuestionCommand.COMMAND_WORD:
+            return new PendingQuestionCommandParser().parse(arguments);
+
+        case RemarkCommand.COMMAND_WORD:
+            return new RemarkCommandParser().parse(arguments);
+
+        case RemoveCommand.COMMAND_WORD:
+            return new RemoveCommandParser().parse(arguments);
 
         case ResetCommand.COMMAND_WORD:
             return new ResetCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/FindCourseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCourseCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindCourseCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.course.CourseNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindCourseCommand object
+ */
+public class FindCourseCommandParser implements Parser<FindCourseCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCourseCommand
+     * and returns a FindCourseCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindCourseCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCourseCommand.MESSAGE_USAGE));
+        }
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+        return new FindCourseCommand(new CourseNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ResetCourseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCourseCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ResetCourseCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ResetCommand object
+ */
+public class ResetCourseCommandParser implements Parser<ResetCourseCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ResetCourseCommand
+     * and returns a ResetCourseCommand object for execution.
+     * @throws ParseException If the user input does not conform to the expected format
+     */
+    public ResetCourseCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        if (argMultimap.getPreamble().isEmpty()) {
+            return new ResetCourseCommand();
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResetCourseCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/main/java/seedu/address/model/course/CourseNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/course/CourseNameContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.course;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Course}'s {@code courseName} matches any of the keywords given.
+ */
+public class CourseNameContainsKeywordsPredicate implements Predicate<Course> {
+    private final List<String> keywords;
+
+    public CourseNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Course course) {
+        return keywords.stream()
+                .anyMatch(keyword -> course.courseName.fullCourseName.toLowerCase().contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CourseNameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        CourseNameContainsKeywordsPredicate otherCourseNameContainsKeywordsPredicate =
+                (CourseNameContainsKeywordsPredicate) other;
+        return keywords.equals(otherCourseNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}


### PR DESCRIPTION
1. Added find course feature: `find KEYWORD`

- It supports substring keyword match.

- It is case-insensitive.

For example, `find CS20` will return CourseList with `CS2030S` and `CS2040S`

2. Added reset course feature: `reset`

For example, `reset` will list out all the current courses.
