### PR TITLE
Fix bug in EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -6,11 +6,11 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.course.CourseName;
-import seedu.address.model.person.SortCriteria;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PendingQuestion;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.SortCriteria;
 import seedu.address.model.tag.StudentRank;
 import seedu.address.model.tag.Tag;
 
@@ -83,9 +83,12 @@ public class ParserUtil {
      * Parses a {@code String remark} into an {@code Remark}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static Remark parseRemark(String remark) {
+    public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);
         String trimmedRemark = remark.trim();
+        if (trimmedRemark.isEmpty()) {
+            throw new ParseException(RemarkCommandParser.MESSAGE_CONSTRAINTS);
+        }
         return new Remark(trimmedRemark);
     }
 
@@ -93,9 +96,12 @@ public class ParserUtil {
      * Parses a {@code String pendingQuestion} into an {@code pendingQuestion}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static PendingQuestion parsePendingQuestion(String pendingQuestion) {
+    public static PendingQuestion parsePendingQuestion(String pendingQuestion) throws ParseException {
         requireNonNull(pendingQuestion);
         String trimmedPendingQuestion = pendingQuestion.trim();
+        if (trimmedPendingQuestion.isEmpty()) {
+            throw new ParseException(PendingQuestionCommandParser.MESSAGE_CONSTRAINTS);
+        }
         return new PendingQuestion(trimmedPendingQuestion);
     }
 


### PR DESCRIPTION
Modify the `parseRemark` and `parsePendingQuestion` methods so that the `edit` command does not permit empty pending questions or empty remarks. The only way to remove a pending question or a remark is by using the `remove` command.